### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,8 +17,16 @@ class ItemsController < ApplicationController
       
   end
 
+  def updata
+      
+  end
+
   def show
-    
+    @item = Item.find(params[:id])
+  end
+
+  def destroy
+      
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index,:show]
+  before_action :set_item, only: [:show]
   
   def index
     @items = Item.order("created_at DESC")
@@ -22,7 +23,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def destroy
@@ -41,5 +41,8 @@ class ItemsController < ApplicationController
   def message_params
     params.require(:item).permit(:name, :price, :image).merge(user_id: current_user.id)
   end
-
+  
+  def set_item
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,21 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% if @item.purchase.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,48 +26,54 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+    <% else  %>
+      <% unless @item.purchase.present? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+      <% end %>
+    <%end %>
 
-    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+   <%# @item.each do |item| %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category_id %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_status_id %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost_burden_id %></td>
         </tr>
+<%# 後でカラム名変更すること、アクティブハッシュで都道府県を他でも使うから prefecture に%>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_place_id %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.ship_date_id %></td>
         </tr>
       </tbody>
     </table>
+   <%# end %>
+
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,12 +8,10 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image,class:"item-box-img" if @item.image.attached? %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <% if @item.purchase.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
       <% end %>
     </div>
     <div class="item-price-box">
@@ -25,17 +23,13 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
     <% else  %>
       <% unless @item.purchase.present? %>
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
-      <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
       <% end %>
     <%end %>
 


### PR DESCRIPTION
商品出品機能未搭載のため画像以外をsequel proでデータベースに記述しました。
商品出品機能　は別ブランチで制作中です。ログイン以外の遷移before_action等も
その別ブランチで制作しております。
他にもアクティブストレージで画像を入れているためまだ商品詳細表示機能ではコード
のみとなっております。同様にアクティブハッシュも商品出品機能に実装予定なのでid
のままです。lgtm頂き次第出品機能追加します。

そのため今回の商品詳細では未ログイン、ログイン時、出品者の外面確認をお願いします。

ログイン時のsoldout商品表記
https://gyazo.com/3ba86e5db44b4c287cca0eb0b7fd2c13
商品画像がないため見にくいですが薄らsoldoutが表記されています。出品機能で画
像付け次第再度確認します。

他ユーザーのまだ売れていない商品の表記
https://gyazo.com/f73192ae2057948b1aac3fbceced0f02

出品者がログインした際の出品商品の確認
https://gyazo.com/bc8d61e30710b7df27d152d7f78280c6

未ログイン時の場合
https://gyazo.com/201f1f15c686072e6e757cd5a874f8c6
未ログイン時のsoldout商品の詳細画面遷移した場合
https://gyazo.com/060e02e230d4bd8fe6b78e33809f8671